### PR TITLE
feature: Updating post schema to accept canonical urls

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -24,6 +24,7 @@ const blog = defineCollection({
       tags: z.array(z.string()),
       author: reference('authors'),
       excerpt: z.string(),
+      canonicalUrl: z.string().optional(),
     }),
 })
 

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -58,6 +58,7 @@ const ogImageUrl = `${Astro.url.origin}/og/article.png?${new URLSearchParams({
       },
     },
     twitter: { creator: author?.data.twitter, image: ogImageUrl },
+    canonical: post.data.canonicalUrl,
   }}
   class='pb-20 lg:pb-40'
 >


### PR DESCRIPTION
Closes #32 

I have implemented the optional parameter in the blog schema called `canonicalUrl`.
Other that I have went to the `/blog/[slug].astro` page and have passed it to the `seo` parameter in the Layout component.

Btw amazing community y'all. Planning to share a blog post on here soon 💚 🚀 