### PR TITLE
Add `astro-capo`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@resvg/resvg-js-linux-x64-gnu": "^2.6.2",
     "@tailwindcss/container-queries": "^0.1.1",
     "astro": "^4.5.15",
+    "astro-capo": "^0.0.1",
     "astro-seo": "^0.8.3",
     "cal-sans": "^1.0.1",
     "date-fns": "^3.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ dependencies:
   astro:
     specifier: ^4.5.15
     version: 4.5.15(@types/node@20.12.4)(typescript@5.4.3)
+  astro-capo:
+    specifier: ^0.0.1
+    version: 0.0.1(astro@4.5.15)
   astro-seo:
     specifier: ^0.8.3
     version: 0.8.3(prettier-plugin-astro@0.13.0)(typescript@5.4.3)
@@ -2103,6 +2106,15 @@ packages:
   /astring@1.8.6:
     resolution: {integrity: sha512-ISvCdHdlTDlH5IpxQJIex7BWBywFWgjJSVdwst+/iQCoEYnyOaQ95+X1JGshuBjGp6nxKUy1jMgE3zPqN7fQdg==}
     hasBin: true
+    dev: false
+
+  /astro-capo@0.0.1(astro@4.5.15):
+    resolution: {integrity: sha512-KyQD1mzgEQnbqrKpYdoIZMAYejkOcIJocdGuQBH9Yzr4KqGzIR8P2DDNbV/FQXaSyq900lCZwWJH45tBIQCG8w==}
+    peerDependencies:
+      astro: '>= 2.8'
+    dependencies:
+      astro: 4.5.15(@types/node@20.12.4)(typescript@5.4.3)
+      ultrahtml: 1.3.0
     dev: false
 
   /astro-seo@0.8.3(prettier-plugin-astro@0.13.0)(typescript@5.4.3):

--- a/src/components/layout.astro
+++ b/src/components/layout.astro
@@ -7,6 +7,8 @@ import '@/styles/global.css'
 import Header from '@/components/header.astro'
 import Footer from '@/components/footer.astro'
 
+import { Head } from 'astro-capo'
+
 type Props = {
   class?: string
   seo?: SEOProps
@@ -41,7 +43,7 @@ const description =
 ---
 
 <html lang='en' class='dark'>
-  <head>
+  <Head>
     <meta charset='utf-8' />
     <link rel='apple-touch-icon' sizes='180x180' href='/apple-touch-icon.png' />
     <link rel='icon' type='image/png' sizes='32x32' href='/favicon-32x32.png' />
@@ -89,7 +91,7 @@ const description =
         ...seo.openGraph,
       }}
     />
-  </head>
+  </Head>
   <body class='min-h-screen overflow-x-hidden bg-rich-black text-white'>
     <Header />
     <main class={twMerge('container mx-auto px-4', className)}>


### PR DESCRIPTION
Adds `astro-capo` to order elements in the <head> which can have an effect on the (perceived) performance of the page.

`astro-capo` automatically optimizes the order of elements in your <head>.


## Before
<img width="596" alt="image" src="https://github.com/creatures-dev/creatures.dev/assets/85648028/c5d7aeba-1c97-48ad-847d-0e29d1e56bc4">

## After

![image](https://github.com/creatures-dev/creatures.dev/assets/85648028/a6a97975-fbe0-4c56-896a-8c791c69d0bc)


